### PR TITLE
Send STOP_BLE before stopping SDL service

### DIFF
--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -77,12 +77,13 @@ public class MainActivity extends AppCompatActivity {
         stop_sdl_button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                stopService(
-                        new Intent(MainActivity.this, SdlLauncherService.class));
                 if (isBleSupported() && isBluetoothPermissionGranted()) {
                     final Intent intent = new Intent(ACTION_STOP_BLE);
                     sendBroadcast(intent);
                 }
+                stopService(
+                        new Intent(MainActivity.this, SdlLauncherService.class));
+
             }
         });
 


### PR DESCRIPTION
We should send STOP_BLE to the Java adapter before stopping the native part so this thread will have a chance to stop the client and server on its side. After that, the native part adapter can be stopped properly.
Otherwise, the server on the native part side can't be disconnected because the Java side is still active and we have to wait 5 seconds and then kill the SDL service.