### PR TITLE
Add possibility to rescan and reconnect BLE devices

### DIFF
--- a/app/src/main/java/org/luxoft/sdl_core/BleCentralService.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BleCentralService.java
@@ -14,8 +14,10 @@ import java.util.TimerTask;
 public class BleCentralService extends Service {
         public static final String TAG = BleCentralService.class.getSimpleName();
         public final static String ACTION_START_BLE = "ACTION_START_BLE";
+        public final static String ACTION_SCAN_BLE = "ACTION_SCAN_BLE";
         public final static String ACTION_STOP_BLE = "ACTION_STOP_BLE";
         public final static String ON_BLE_PERIPHERAL_READY = "ON_BLE_PERIPHERAL_READY";
+        public final static String ON_BLE_SCAN_STARTED = "ON_BLE_SCAN_STARTED";
         public final static String ON_NATIVE_BLE_READY = "ON_NATIVE_BLE_READY";
         public final static String ON_NATIVE_BLE_CONTROL_READY = "ON_NATIVE_BLE_CONTROL_READY";
         public final static String ON_MOBILE_MESSAGE_RECEIVED = "ON_MOBILE_MESSAGE_RECEIVED";
@@ -66,6 +68,16 @@ public class BleCentralService extends Service {
                         Log.i(TAG, "ACTION_START_BLE received by centralServiceReceiver");
                         mNativeBleAdapterThread = new JavaToNativeBleAdapter(BleCentralService.this);
                         mNativeBleAdapterThread.start();
+                        break;
+
+                    case ACTION_SCAN_BLE:
+                        Log.i(TAG, "ACTION_SCAN_BLE received by centralServiceReceiver");
+                        if (mBluetoothHandler != null) {
+                            mBluetoothHandler.connect();
+                        }
+
+                        final Intent scan_started_intent = new Intent(ON_BLE_SCAN_STARTED);
+                        context.sendBroadcast(scan_started_intent);
                         break;
 
                     case ACTION_STOP_BLE:
@@ -131,6 +143,7 @@ public class BleCentralService extends Service {
     private static IntentFilter makeCentralServiceIntentFilter() {
         final IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(ACTION_START_BLE);
+        intentFilter.addAction(ACTION_SCAN_BLE);
         intentFilter.addAction(ACTION_STOP_BLE);
         intentFilter.addAction(ON_NATIVE_BLE_READY);
         intentFilter.addAction(ON_NATIVE_BLE_CONTROL_READY);

--- a/app/src/main/java/org/luxoft/sdl_core/BleCentralService.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BleCentralService.java
@@ -23,7 +23,9 @@ public class BleCentralService extends Service {
         public final static String ON_MOBILE_MESSAGE_RECEIVED = "ON_MOBILE_MESSAGE_RECEIVED";
         public final static String MOBILE_DATA_EXTRA = "MOBILE_DATA_EXTRA";
         public final static String MOBILE_CONTROL_DATA_EXTRA = "MOBILE_CONTROL_DATA_EXTRA";
+        public final static String MOBILE_DEVICE_DISCONNECTED_EXTRA = "MOBILE_DEVICE_DISCONNECTED_EXTRA";
         public final static String ON_MOBILE_CONTROL_MESSAGE_RECEIVED = "ON_MOBILE_CONTROL_MESSAGE_RECEIVED";
+
         BluetoothHandler mBluetoothHandler;
         JavaToNativeBleAdapter mNativeBleAdapterThread;
         BleAdapterWriteMessageCallback mCallback;
@@ -47,7 +49,6 @@ public class BleCentralService extends Service {
 
         private void initBluetoothHandler(){
             mBluetoothHandler = BluetoothHandler.getInstance(this);
-            mBluetoothHandler.connect();
         }
 
         @Override
@@ -131,6 +132,9 @@ public class BleCentralService extends Service {
                         byte[] mobile_control_message = intent.getByteArrayExtra(MOBILE_CONTROL_DATA_EXTRA);
                         if (mNativeBleAdapterThread != null) {
                             mNativeBleAdapterThread.SendControlMessageToNative(mobile_control_message);
+                            if (intent.getBooleanExtra(MOBILE_DEVICE_DISCONNECTED_EXTRA, false)) {
+                                mNativeBleAdapterThread.CloseConnectionWithNative();
+                            }
                         }
                         break;
 

--- a/app/src/main/java/org/luxoft/sdl_core/BluetoothHandler.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BluetoothHandler.java
@@ -21,6 +21,7 @@ import org.json.JSONObject;
 import java.util.UUID;
 
 import static android.bluetooth.BluetoothGattCharacteristic.PROPERTY_WRITE;
+import static org.luxoft.sdl_core.BleCentralService.ACTION_SCAN_BLE;
 import static org.luxoft.sdl_core.BleCentralService.MOBILE_DATA_EXTRA;
 import static org.luxoft.sdl_core.BleCentralService.ON_MOBILE_MESSAGE_RECEIVED;
 import static org.luxoft.sdl_core.BleCentralService.ON_BLE_PERIPHERAL_READY;
@@ -173,13 +174,9 @@ class BluetoothHandler {
                     context.sendBroadcast(intent);
                 }
 
-                // Reconnect to this device when it becomes available again
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        central.autoConnectPeripheral(peripheral, peripheralCallback);
-                    }
-                }, 5000);
+                // Restart devices scanning
+                final Intent scan_ble = new Intent(ACTION_SCAN_BLE);
+                context.sendBroadcast(scan_ble);
             }
         }
 

--- a/app/src/main/java/org/luxoft/sdl_core/BluetoothHandler.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BluetoothHandler.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import static android.bluetooth.BluetoothGattCharacteristic.PROPERTY_WRITE;
 import static org.luxoft.sdl_core.BleCentralService.ACTION_SCAN_BLE;
 import static org.luxoft.sdl_core.BleCentralService.MOBILE_DATA_EXTRA;
+import static org.luxoft.sdl_core.BleCentralService.MOBILE_DEVICE_DISCONNECTED_EXTRA;
 import static org.luxoft.sdl_core.BleCentralService.ON_MOBILE_MESSAGE_RECEIVED;
 import static org.luxoft.sdl_core.BleCentralService.ON_BLE_PERIPHERAL_READY;
 import static org.luxoft.sdl_core.BleCentralService.ON_MOBILE_CONTROL_MESSAGE_RECEIVED;
@@ -171,8 +172,12 @@ class BluetoothHandler {
                 if(ctrl_msg != null) {
                     final Intent intent = new Intent(ON_MOBILE_CONTROL_MESSAGE_RECEIVED);
                     intent.putExtra(MOBILE_CONTROL_DATA_EXTRA, ctrl_msg.getBytes());
+                    intent.putExtra(MOBILE_DEVICE_DISCONNECTED_EXTRA, true);
                     context.sendBroadcast(intent);
                 }
+
+                mLongReader.resetBuffer();
+                mLongWriter.resetBuffer();
 
                 // Restart devices scanning
                 final Intent scan_ble = new Intent(ACTION_SCAN_BLE);

--- a/app/src/main/java/org/luxoft/sdl_core/BluetoothLongReader.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BluetoothLongReader.java
@@ -65,8 +65,8 @@ public class BluetoothLongReader {
                 final byte[] full_message = Arrays.copyOf(mBuffer.array(), mBuffer.capacity() - mBuffer.remaining());
                 mCallback.OnLongMessageReceived(full_message);
             }
-            mBuffer.clear();
-            mBuffer = null;
+
+            resetBuffer();
         }
     }
 }

--- a/app/src/main/java/org/luxoft/sdl_core/BluetoothLongReader.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BluetoothLongReader.java
@@ -27,6 +27,14 @@ public class BluetoothLongReader {
         mCallback = callback;
     }
 
+    public void resetBuffer() {
+        Log.d(TAG, "Resetting reader buffer");
+        if (mBuffer != null) {
+            mBuffer.clear();
+            mBuffer = null;
+        }
+    }
+
     private int extractFramesCount(byte[] value) {
         byte[] frames = Arrays.copyOfRange(value, 0, mMessageOffset);
         return ByteBuffer.wrap(frames).getInt();

--- a/app/src/main/java/org/luxoft/sdl_core/BluetoothLongWriter.java
+++ b/app/src/main/java/org/luxoft/sdl_core/BluetoothLongWriter.java
@@ -30,6 +30,12 @@ public class BluetoothLongWriter {
         mCallback = callback;
     }
 
+    public void resetBuffer() {
+        Log.d(TAG, "Resetting writer queue");
+        mMessagesToSend.clear();
+        mSendInProgress = false;
+    }
+
     private byte[] prepareMessageToSend(final int frames_left, final byte[] message) {
         ByteBuffer buffer = ByteBuffer.allocate(message.length + mFramesCountBytes);
         buffer.putInt(frames_left);

--- a/app/src/main/java/org/luxoft/sdl_core/JavaToNativeBleAdapter.java
+++ b/app/src/main/java/org/luxoft/sdl_core/JavaToNativeBleAdapter.java
@@ -18,6 +18,7 @@ public class JavaToNativeBleAdapter extends Thread {
     private static final int CONNECT_CONTROL_WRITER_ID = 4;
     private static final int CONNECT_READER_ID = 5;
     private static final int CONNECT_WRITER_ID = 6;
+    private static final int DISCONNECT_ID = 7;
     public static final String CONTROL_SOCKET_ADDRESS = "./localBleControl";
     public static final String WRITER_SOCKET_ADDRESS = "./localBleWriter";
 
@@ -38,6 +39,12 @@ public class JavaToNativeBleAdapter extends Thread {
     public void EstablishConnectionWithNative() {
         Log.i(TAG, "Establishing communication with native");
         Message message = mHandler.obtainMessage(CONNECT_READER_ID);
+        mHandler.sendMessage(message);
+    }
+
+    public void CloseConnectionWithNative() {
+        Log.i(TAG, "Closing communication with native");
+        Message message = mHandler.obtainMessage(DISCONNECT_ID);
         mHandler.sendMessage(message);
     }
 
@@ -106,6 +113,13 @@ public class JavaToNativeBleAdapter extends Thread {
                                 mContext.sendBroadcast(intent);
                             }
                         });
+                        break;
+                    case DISCONNECT_ID:
+                        Log.i(TAG, "Disconnecting BLE reader");
+                        mReader.Disconnect();
+
+                        Log.i(TAG, "Disconnecting BLE writer");
+                        mWriter.Disconnect();
                         break;
                 }
             }

--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -1,7 +1,15 @@
 package org.luxoft.sdl_core;
 
+import static org.luxoft.sdl_core.BleCentralService.ACTION_SCAN_BLE;
+import static org.luxoft.sdl_core.BleCentralService.ACTION_START_BLE;
+import static org.luxoft.sdl_core.BleCentralService.ACTION_STOP_BLE;
+import static org.luxoft.sdl_core.BleCentralService.ON_BLE_SCAN_STARTED;
+import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STARTED;
+import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STOPPED;
+
 import android.Manifest;
 import android.app.ProgressDialog;
+import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -19,7 +27,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
-
 import androidx.core.app.ActivityCompat;
 import androidx.documentfile.provider.DocumentFile;
 
@@ -31,13 +38,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import android.bluetooth.BluetoothAdapter;
-
-import static org.luxoft.sdl_core.BleCentralService.ACTION_START_BLE;
-import static org.luxoft.sdl_core.BleCentralService.ACTION_STOP_BLE;
-
-import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STOPPED;
-import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STARTED;
 public class MainActivity extends AppCompatActivity {
 
     static final String TAG = MainActivity.class.getSimpleName();
@@ -413,6 +413,13 @@ public class MainActivity extends AppCompatActivity {
                     start_sdl_button.setEnabled(false);
                     stop_sdl_button.setEnabled(true);
                     showToastMessage("SDL service has been started");
+
+                    final Intent scan_intent = new Intent(ACTION_SCAN_BLE);
+                    sendBroadcast(scan_intent);
+                    break;
+
+                case ON_BLE_SCAN_STARTED:
+                    showToastMessage("Scanning for a BLE devices nearby...");
                     break;
             }
         }
@@ -422,6 +429,7 @@ public class MainActivity extends AppCompatActivity {
         final IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(ON_SDL_SERVICE_STOPPED);
         intentFilter.addAction(ON_SDL_SERVICE_STARTED);
+        intentFilter.addAction(ON_BLE_SCAN_STARTED);
         return intentFilter;
     }
 


### PR DESCRIPTION
This is an implementation update containing the following changes:
- Added separate intent action for the implicit start of BLE devices scanning from BleCentralService
- Added new action for notifying MainActivity that BLE scanning has been started
- Added new flag to control message to additionally notify about device disconnection
- Added a new function in JavaToNativeBleAdapter to stop server and client used for data exchange with a native part. These two components should be stopped if the BLE connection gets disconnected and will be started again on the next reconnect
- Added a new function to long reader and writer classes to reset the internal flags and buffers in case of device disconnection. Otherwise, they may contain old data from a previous connection
- Added BLE scan restart once the connection with the current device is lost