### PR TITLE
[Fix] Crash when running on lower versions of Android

### DIFF
--- a/app/src/main/java/org/luxoft/sdl_core/AndroidTool.java
+++ b/app/src/main/java/org/luxoft/sdl_core/AndroidTool.java
@@ -1,0 +1,24 @@
+package org.luxoft.sdl_core;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+public class AndroidTool {
+
+    /**
+     * Service needs to be foregrounded in Android O and above.
+     * This will prevent apps in the background from crashing when they try to start SdlService,
+     * because Android O doesn't allow background apps to start background services.
+     * */
+    public static void startService(@NonNull Context context, @NonNull Intent intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+}

--- a/app/src/main/java/org/luxoft/sdl_core/AndroidTool.java
+++ b/app/src/main/java/org/luxoft/sdl_core/AndroidTool.java
@@ -12,6 +12,9 @@ public class AndroidTool {
      * Service needs to be foregrounded in Android O and above.
      * This will prevent apps in the background from crashing when they try to start SdlService,
      * because Android O doesn't allow background apps to start background services.
+     *
+     * @param context   The object to use to start service.
+     * @param intent    The object to identify the service to be started. The Intent must be fully explicit.
      * */
     public static void startService(@NonNull Context context, @NonNull Intent intent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -4,6 +4,7 @@ import static org.luxoft.sdl_core.BleCentralService.ACTION_SCAN_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ACTION_START_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ACTION_STOP_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ON_BLE_SCAN_STARTED;
+import static org.luxoft.sdl_core.SdlLauncherService.IS_SDL_SERVICE_THREAD_ALIVE;
 import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STARTED;
 import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STOPPED;
 
@@ -67,8 +68,10 @@ public class MainActivity extends AppCompatActivity {
         start_sdl_button = findViewById(R.id.start_sdl_button);
         stop_sdl_button = findViewById(R.id.stop_sdl_button);
 
-        start_sdl_button.setEnabled(true);
-        stop_sdl_button.setEnabled(false);
+        Intent intent = getIntent();
+        boolean isSdlThreadAlive = intent != null && intent.getBooleanExtra(IS_SDL_SERVICE_THREAD_ALIVE, false);
+        start_sdl_button.setEnabled(!isSdlThreadAlive);
+        stop_sdl_button.setEnabled(isSdlThreadAlive);
 
         start_sdl_button.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -114,7 +117,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && !isSdlThreadAlive) {
             initBT();
         }
         if (isBleSupported() && isBluetoothPermissionGranted()) {

--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -4,7 +4,6 @@ import static org.luxoft.sdl_core.BleCentralService.ACTION_SCAN_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ACTION_START_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ACTION_STOP_BLE;
 import static org.luxoft.sdl_core.BleCentralService.ON_BLE_SCAN_STARTED;
-import static org.luxoft.sdl_core.SdlLauncherService.IS_SDL_SERVICE_THREAD_ALIVE;
 import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STARTED;
 import static org.luxoft.sdl_core.SdlLauncherService.ON_SDL_SERVICE_STOPPED;
 
@@ -68,10 +67,8 @@ public class MainActivity extends AppCompatActivity {
         start_sdl_button = findViewById(R.id.start_sdl_button);
         stop_sdl_button = findViewById(R.id.stop_sdl_button);
 
-        Intent intent = getIntent();
-        boolean isSdlThreadAlive = intent != null && intent.getBooleanExtra(IS_SDL_SERVICE_THREAD_ALIVE, false);
-        start_sdl_button.setEnabled(!isSdlThreadAlive);
-        stop_sdl_button.setEnabled(isSdlThreadAlive);
+        start_sdl_button.setEnabled(true);
+        stop_sdl_button.setEnabled(false);
 
         start_sdl_button.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -117,7 +114,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        if (savedInstanceState == null && !isSdlThreadAlive) {
+        if (savedInstanceState == null) {
             initBT();
         }
         if (isBleSupported() && isBluetoothPermissionGranted()) {

--- a/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
+++ b/app/src/main/java/org/luxoft/sdl_core/MainActivity.java
@@ -77,7 +77,7 @@ public class MainActivity extends AppCompatActivity {
                 stop_sdl_button.setEnabled(false);
                 Intent start_intent = new Intent(MainActivity.this, SdlLauncherService.class);
                 start_intent.setAction(ACTION_SDL_SERVICE_START);
-                startService(start_intent);
+                AndroidTool.startService(MainActivity.this, start_intent);
 
                 if (isBleSupported() && isBluetoothPermissionGranted()) {
                     final Intent intent = new Intent(ACTION_START_BLE);
@@ -96,7 +96,7 @@ public class MainActivity extends AppCompatActivity {
               
                 Intent stop_intent = new Intent(MainActivity.this, SdlLauncherService.class);
                 stop_intent.setAction(ACTION_SDL_SERVICE_STOP);
-                startService(stop_intent);
+                AndroidTool.startService(MainActivity.this, stop_intent);
             }
         });
 

--- a/app/src/main/java/org/luxoft/sdl_core/SdlLauncherService.java
+++ b/app/src/main/java/org/luxoft/sdl_core/SdlLauncherService.java
@@ -1,6 +1,5 @@
 package org.luxoft.sdl_core;
 
-import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -22,6 +21,7 @@ public class SdlLauncherService extends Service {
 
     public final static String ACTION_SDL_SERVICE_START = "ACTION_SDL_SERVICE_START";
     public final static String ACTION_SDL_SERVICE_STOP = "ACTION_SDL_SERVICE_STOP";
+    public final static String IS_SDL_SERVICE_THREAD_ALIVE = "IS_SDL_SERVICE_THREAD_ALIVE";
     public final static String ON_SDL_SERVICE_STOPPED = "org.luxoft.sdl_core.ON_SDL_SERVICE_STOPPED";
     public final static String ON_SDL_SERVICE_STARTED = "org.luxoft.sdl_core.ON_SDL_SERVICE_STARTED";
 
@@ -149,8 +149,12 @@ public class SdlLauncherService extends Service {
 
     private Notification getServiceNotification(String text){
         // The PendingIntent to launch our activity if the user selects this notification
-        PendingIntent contentIntent = PendingIntent.getActivity(this,
-                0,new Intent(this, SdlLauncherService.class),0);
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        boolean isThreadAlive = sdl_thread_ != null && sdl_thread_.isAlive();
+        intent.putExtra(IS_SDL_SERVICE_THREAD_ALIVE, isThreadAlive);
+
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (channel_id == null) {

--- a/app/src/main/java/org/luxoft/sdl_core/SdlLauncherService.java
+++ b/app/src/main/java/org/luxoft/sdl_core/SdlLauncherService.java
@@ -21,7 +21,6 @@ public class SdlLauncherService extends Service {
 
     public final static String ACTION_SDL_SERVICE_START = "ACTION_SDL_SERVICE_START";
     public final static String ACTION_SDL_SERVICE_STOP = "ACTION_SDL_SERVICE_STOP";
-    public final static String IS_SDL_SERVICE_THREAD_ALIVE = "IS_SDL_SERVICE_THREAD_ALIVE";
     public final static String ON_SDL_SERVICE_STOPPED = "org.luxoft.sdl_core.ON_SDL_SERVICE_STOPPED";
     public final static String ON_SDL_SERVICE_STARTED = "org.luxoft.sdl_core.ON_SDL_SERVICE_STARTED";
 
@@ -151,10 +150,8 @@ public class SdlLauncherService extends Service {
         // The PendingIntent to launch our activity if the user selects this notification
         Intent intent = new Intent(this, MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        boolean isThreadAlive = sdl_thread_ != null && sdl_thread_.isAlive();
-        intent.putExtra(IS_SDL_SERVICE_THREAD_ALIVE, isThreadAlive);
 
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (channel_id == null) {


### PR DESCRIPTION
Fix #11 

### Problems
* Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel. 
Lower versions of Android (API level <= 25) don't now anything about notification channel and it was a reason why this crash occurs.
* Starting in Android 9.0 (API level 28) we should start service in foreground and show notification to the user.  

### Changes
* Added version check before service start. For API level >= 28 service will be started in foreground and in background otherwise.  
* Added notifications for API level <= 25 
* Added ability to open MainActivity after click on the notification. Changed UI init state. 

### Testing 
- [x] I have started core on the emulator with API 28 and connected hmi + another emulator (SPT)
- [x] I have started core on the emulator with API 25 and connected hmi + another emulator (SPT)